### PR TITLE
Tweak UI and Copilot shortcuts

### DIFF
--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -1,3 +1,8 @@
 return {
-  "https://github.com/github/copilot.vim",
+  "github/copilot.vim",
+  keys = {
+    { "<leader>ce", "<cmd>Copilot enable<cr>", desc = "Copilot Enable" },
+    { "<leader>cd", "<cmd>Copilot disable<cr>", desc = "Copilot Disable" },
+    { "<leader>cp", "<cmd>Copilot panel<cr>", desc = "Copilot Panel" },
+  },
 }

--- a/lua/plugins/noice.lua
+++ b/lua/plugins/noice.lua
@@ -1,0 +1,8 @@
+return {
+  "folke/noice.nvim",
+  opts = {
+    notify = {
+      enabled = false,
+    },
+  },
+}

--- a/lua/plugins/whichkey.lua
+++ b/lua/plugins/whichkey.lua
@@ -1,0 +1,8 @@
+return {
+  "folke/which-key.nvim",
+  opts = {
+    window = {
+      position = "bottom",
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- position the which-key window at the bottom
- disable notification view from noice
- register some Copilot shortcuts with which-key

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ae285aaf883318132f0711a0db4ec

## Summary by Sourcery

Add Copilot keybindings, disable Noice notifications, and reposition Which-Key window for improved development workflow

New Features:
- Register <leader>ce, <leader>cd, and <leader>cp shortcuts for Copilot commands

Enhancements:
- Set Which-Key window position to bottom
- Disable notification view in Noice.nvim