### PR TITLE
Tweak UI and Copilot shortcuts

### DIFF
--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -1,3 +1,8 @@
 return {
-  "https://github.com/github/copilot.vim",
+  "github/copilot.vim",
+  keys = {
+    { "<leader>ce", "<cmd>Copilot enable<cr>", desc = "Copilot Enable" },
+    { "<leader>cd", "<cmd>Copilot disable<cr>", desc = "Copilot Disable" },
+    { "<leader>cp", "<cmd>Copilot panel<cr>", desc = "Copilot Panel" },
+  },
 }

--- a/lua/plugins/noice.lua
+++ b/lua/plugins/noice.lua
@@ -1,0 +1,8 @@
+return {
+  "folke/noice.nvim",
+  opts = {
+    notify = {
+      enabled = false,
+    },
+  },
+}

--- a/lua/plugins/whichkey.lua
+++ b/lua/plugins/whichkey.lua
@@ -1,0 +1,15 @@
+return {
+  "folke/which-key.nvim",
+  opts = {
+    win = {
+      position = "bottom",
+    },
+  },
+  config = function(_, opts)
+    local wk = require("which-key")
+    wk.setup(opts)
+    wk.register({
+      ["<leader>c"] = { name = "+copilot" },
+    })
+  end,
+}


### PR DESCRIPTION
## Summary
- position the which-key window at the bottom using the new `win` option
- disable noice notifications
- register Copilot key mappings under a group in which-key

## Testing
- `stylua lua/plugins/whichkey.lua lua/plugins/noice.lua lua/plugins/copilot.lua`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ae285aaf883318132f0711a0db4ec